### PR TITLE
[app] Initialize FastAPI template

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+PROJECT_NAME=FastAPI Template
+DEBUG=True

--- a/app/api/v1/example.py
+++ b/app/api/v1/example.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/ping")
+def ping() -> dict[str, str]:
+    return {"ping": "pong"}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+
+from pydantic import BaseSettings, Field, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    project_name: str = Field("FastAPI Template", alias="PROJECT_NAME")
+    debug: bool = Field(False, alias="DEBUG")
+
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", populate_by_name=True
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from dotenv import load_dotenv
+
+from app.core.config import get_settings
+from app.api.v1 import example
+
+load_dotenv()
+settings = get_settings()
+
+app = FastAPI(title=settings.project_name, debug=settings.debug)
+
+app.include_router(example.router, prefix="/api/v1")
+
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    return {"message": "Welcome"}

--- a/app/services/ai.py
+++ b/app/services/ai.py
@@ -1,0 +1,3 @@
+def generate_response(prompt: str) -> str:
+    """Return a dummy AI generated response."""
+    return f"Echo: {prompt}"

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+def test_ping() -> None:
+    response = client.get("/api/v1/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ping": "pong"}


### PR DESCRIPTION
## What
- bootstrap FastAPI project structure
- add versioned `/api/v1` router with `/ping`
- implement configuration via `BaseSettings`
- add dummy AI service
- provide basic ping test

## Why
- establish minimal FastAPI template with env‑based configuration
- ensure routing and test structure work as a base for extensions

## How
- create routers and settings in `/app`
- wire them up in `main.py`
- create simple pytest to validate ping endpoint


------
https://chatgpt.com/codex/tasks/task_e_687a7cb557f083309fb4eb5d2bf49eb9