### PR TITLE
[init] Rename to Bookkeeping Dashboard

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-PROJECT_NAME=FastAPI Template
+PROJECT_NAME=Bookkeeping Dashboard
 DEBUG=True

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Bookkeeping Dashboard
+
+This project is generated from the FastAPI template and renamed for the Bookkeeping Dashboard service.

--- a/app/app.py
+++ b/app/app.py
@@ -4,13 +4,11 @@ from fastapi import FastAPI
 from app.api.v1 import example
 from app.core.config import get_settings
 
+
 def create_app() -> FastAPI:
     settings = get_settings()
 
-    app = FastAPI(
-        title=settings.project_name,
-        debug=settings.debug
-    )
+    app = FastAPI(title=settings.project_name, debug=settings.debug)
 
     app.include_router(example.router, prefix="/api/v1")
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,7 +5,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    project_name: str = "FastAPI Codex Template"
+    project_name: str = "Bookkeeping Dashboard"
     debug: bool = True
 
     class Config:

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from app.core.config import get_settings
 from app.api.v1 import example
 
 # Local imports
-from app.app import create_app 
+from app.app import create_app
 
 app = create_app()
 
@@ -20,5 +20,3 @@ app.include_router(example.router, prefix="/api/v1")
 @app.get("/")
 def read_root() -> dict[str, str]:
     return {"message": "Welcome"}
-
-


### PR DESCRIPTION
## What
- rename FastAPI template to **Bookkeeping Dashboard**
- update project settings
- format code

## Why
- initialize template for new bookkeeping-dashboard service

## How
- replaced the default project name in config and env files
- updated README
- ran `black` on app/
- attempted to run tests and push to remote (failed due to missing dependencies and network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_687a8bafb3588330b8b5b75a4f3ba441