### PR TITLE
[app] undo rename changes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,13 +4,11 @@ from fastapi import FastAPI
 from app.api.v1 import example
 from app.core.config import get_settings
 
+
 def create_app() -> FastAPI:
     settings = get_settings()
 
-    app = FastAPI(
-        title=settings.project_name,
-        debug=settings.debug
-    )
+    app = FastAPI(title=settings.project_name, debug=settings.debug)
 
     app.include_router(example.router, prefix="/api/v1")
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from app.core.config import get_settings
 from app.api.v1 import example
 
 # Local imports
-from app.app import create_app 
+from app.app import create_app
 
 app = create_app()
 
@@ -20,5 +20,3 @@ app.include_router(example.router, prefix="/api/v1")
 @app.get("/")
 def read_root() -> dict[str, str]:
     return {"message": "Welcome"}
-
-


### PR DESCRIPTION
## What
- revert rename of project files

## Why
- restore initial FastAPI template setup

## How
- ran `git revert` to undo Bookkeeping Dashboard changes
- formatted app directory with black
- attempted to run tests (failed: missing fastapi)


------
https://chatgpt.com/codex/tasks/task_e_687a8bafb3588330b8b5b75a4f3ba441